### PR TITLE
Fix the eager/lazy evaluation example in chapter8

### DIFF
--- a/src/main/scala/ch08_SchedulingMeetings.scala
+++ b/src/main/scala/ch08_SchedulingMeetings.scala
@@ -1,7 +1,9 @@
 // note that we need two imports (see build.sbt for details)
 import cats.effect.IO
-import cats.implicits._
+import cats.implicits.*
 import cats.effect.unsafe.implicits.global
+
+import scala.util.Try
 
 /** PREREQUISITE 1: MeetingTime model
   */
@@ -147,18 +149,16 @@ object ch08_SchedulingMeetings {
   }
 
   private def lazyEvaluation = {
-    val program = IO.pure(2022).orElse(IO.delay(throw new Exception))
+    val program = IO.delay(throw new Exception).orElse(IO.pure(2022))
     assert(program.isInstanceOf[IO[Int]])
     assert(program.unsafeRunSync() == 2022)
   }
 
   private def eagerEvaluation = {
-    try {
-      val program = IO.pure(2022).orElse(IO.pure(throw new Exception))
+    assert(Try {
+      val program = IO.pure(throw new Exception).orElse(IO.pure(2022))
       assert(program.isInstanceOf[IO[Int]])
-    } catch {
-      case e: Throwable => assert(e.getMessage == null)
-    }
+    }.isFailure)
   }
 
   private def recoveryStrategies = {


### PR DESCRIPTION
As @gitgithan noticed in #152, there is a problem in examples for lazy/eager evaluation. The problem appears because `IO.orElse` takes a block of code lazily so it should not be used as an example for eager evaluation 🤦 .

Here are the correct examples:

```
IO.delay(throw new Exception).orElse(IO.pure(2022)) // lazy, doesn't throw, returns 2022 when run
IO.pure(throw new Exception).orElse(IO.pure(2022)) // eager, throws before creating a value
```

Closes #152