### PR TITLE
Pin Scala version to LTS

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId="scala-library", version = "3.3." },
+]
+updatePullRequests = "always"


### PR DESCRIPTION
`3.3.x` is LTS, let's pin this for now. See https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html